### PR TITLE
Adding RPC Bind to 0.0.0.0 to coind run

### DIFF
--- a/bin/commands
+++ b/bin/commands
@@ -232,6 +232,7 @@ runCoind() {
         -rpcallowip=$ELECTRUMX_HOST/0 \
         -rpcuser=$RPC_USER \
         -rpcpassword=$RPC_PASSWORD \
+        -rpcbind=0.0.0.0 \
         -server=1 \
         -disablewallet \
         -txindex=1 \


### PR DESCRIPTION
After updating Vertcoin to new version, it [requires](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.18.0.md) setting RPC bind parameter.


"The rpcallowip option can no longer be used to automatically listen on all network interfaces. Instead, the rpcbind parameter must be used to specify the IP addresses to listen on. Listening for RPC commands over a public network connection is insecure and should be disabled, so a warning is now printed if a user selects such a configuration. If you need to expose RPC in order to use a tool like Docker, ensure you only bind RPC to your localhost, e.g. docker run [...] -p 127.0.0.1:8332:8332 (this is an extra :8332 over the normal Docker port specification)."